### PR TITLE
Use router method 'authegy_routes' instead of 'devise_for'

### DIFF
--- a/lib/authegy/engine.rb
+++ b/lib/authegy/engine.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'authegy/rails/routes'
+
 module Authegy
   class Engine < ::Rails::Engine
     isolate_namespace Authegy

--- a/lib/authegy/rails/routes.rb
+++ b/lib/authegy/rails/routes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module ActionDispatch
+  module Routing
+    class Mapper
+      def authegy_routes(options = {})
+        # Remove the keys that would interfere with the authegy way:
+        options.extract! :class_name, # We'll only use 'User'
+                         :path,       # All devise paths available from root
+                         :singular    # No 'resource name' required
+
+        default_path_names = { sign_in: 'sign-in', sign_out: 'sign-out' }
+        options.reverse_merge! path: '/', path_names: default_path_names
+
+        devise_for :users, options
+      end
+    end
+  end
+end

--- a/lib/generators/authegy/install_generator.rb
+++ b/lib/generators/authegy/install_generator.rb
@@ -19,11 +19,7 @@ class InstallGenerator < Rails::Generators::Base
     generate 'authegy:models People'
   end
 
-  def add_devise_routes
-    route <<~STRING
-      devise_for :users,
-                 path: '/',
-                 path_names: { sign_in: 'sign-in', sign_out: 'sign-out' }
-    STRING
+  def add_autegy_routes
+    route 'authegy_routes'
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
+  authegy_routes
   root to: 'user_groups#index'
 
   resources :group_posts
   resources :user_groups
-
-  authegy_routes
 
   # For details on the DSL available within this file,
   # see http://guides.rubyonrails.org/routing.html

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,9 +4,7 @@ Rails.application.routes.draw do
   resources :group_posts
   resources :user_groups
 
-  devise_for :users,
-             path: '/',
-             path_names: { sign_in: 'sign-in', sign_out: 'sign-out' }
+  authegy_routes
 
   # For details on the DSL available within this file,
   # see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
# What does this PR do?

* Adds the `authegy_routes` router method
* Uses `authegy_routes` instead of  `devise_for` on the `authegy:install` generator