### PR TITLE
Fixed User Signup

### DIFF
--- a/lib/authegy/models/user.rb
+++ b/lib/authegy/models/user.rb
@@ -15,7 +15,11 @@ module Authegy
     devise :database_authenticatable_with_person_email,
            :validatable_with_person_email
 
-    belongs_to :person, inverse_of: :user, foreign_key: :id
+    belongs_to :person,
+               class_name: '::Person',
+               inverse_of: :user,
+               foreign_key: :id
+
     delegate :email, :email=, :name, to: :person, allow_nil: true
 
     delegate :assigned_roles, :assign_role, :has_role?, :has_any_role?,

--- a/lib/authegy/models/user.rb
+++ b/lib/authegy/models/user.rb
@@ -20,7 +20,12 @@ module Authegy
                inverse_of: :user,
                foreign_key: :id
 
-    delegate :email, :email=, :name, to: :person, allow_nil: true
+    delegate :email, :name, to: :person, allow_nil: true
+
+    def email=(value)
+      return person.email = value if person.present?
+      build_person(email: value).email
+    end
 
     delegate :assigned_roles, :assign_role, :has_role?, :has_any_role?,
              :remove_role, :role_assignments, to: :person

--- a/lib/generators/authegy/templates/models_migration.erb
+++ b/lib/generators/authegy/templates/models_migration.erb
@@ -10,8 +10,8 @@ class CreateAuthegyModelTables < ActiveRecord::Migration<%= migration_version %>
 
   def create_people_table
     create_table :people do |t|
-      t.string :first_name, null: false
-      t.string :last_name, null: false
+      t.string :first_name
+      t.string :last_name
       t.string :email, index: { unique: true }
 
       # Feel free to add additional fields, such as 'nickname', etc:

--- a/spec/dummy/db/migrate/20190302060302_create_authegy_model_tables.rb
+++ b/spec/dummy/db/migrate/20190302060302_create_authegy_model_tables.rb
@@ -10,8 +10,8 @@ class CreateAuthegyModelTables < ActiveRecord::Migration[5.2]
 
   def create_people_table
     create_table :people do |t|
-      t.string :first_name, null: false
-      t.string :last_name, null: false
+      t.string :first_name
+      t.string :last_name
       t.string :email, index: { unique: true }
 
       # Feel free to add additional fields, such as 'nickname', etc:

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -24,8 +24,8 @@ ActiveRecord::Schema.define(version: 2019_03_02_165754) do
   end
 
   create_table "people", force: :cascade do |t|
-    t.string "first_name", null: false
-    t.string "last_name", null: false
+    t.string "first_name"
+    t.string "last_name"
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# What does this PR do?

Fixes the "Signup" process, where the `User` is created directly, but failed to create an associated `Person` object:

* Makes the suggested `first_name` and `last_name` fields from the `people` table nullable on the generated install migration.
* Fixes the `belongs_to :person` options on `Authegy::User` model.
* Builds the associated `Person` object when assigning an `email` to a `User` object.